### PR TITLE
[mod] ArgoCD 연동을 위한 secret생성 로직 수정

### DIFF
--- a/controllers/cluster/clustermanager_controller_phases.go
+++ b/controllers/cluster/clustermanager_controller_phases.go
@@ -461,6 +461,7 @@ func (r *ClusterManagerReconciler) CreateTraefikResources(ctx context.Context, c
 	// 	return ctrl.Result{}, err
 	// }
 
+	log.Info("Create traefik resources successfully")
 	clusterManager.Status.TraefikReady = true
 	return ctrl.Result{}, nil
 }
@@ -498,7 +499,7 @@ func (r *ClusterManagerReconciler) CreateArgocdClusterSecret(ctx context.Context
 		Get(context.TODO(), util.ArgoServiceAccountTokenSecret, metav1.GetOptions{})
 	if err != nil {
 		log.Error(err, "Failed to get service account token secret")
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
 	// ArgoCD single cluster 연동을 위한 secret에 들어가야 할 데이터를 생성
@@ -564,6 +565,7 @@ func (r *ClusterManagerReconciler) CreateArgocdClusterSecret(ctx context.Context
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	log.Info("Create argocd cluster secret successfully")
 	clusterManager.Status.ArgoReady = true
 	return ctrl.Result{}, nil
 }
@@ -657,6 +659,7 @@ func (r *ClusterManagerReconciler) CreateMonitoringResources(ctx context.Context
 	// 	return ctrl.Result{}, err
 	// }
 
+	log.Info("Create monitoring resources successfully")
 	clusterManager.Status.MonitoringReady = true
 	clusterManager.Status.PrometheusReady = true
 	return ctrl.Result{}, nil
@@ -781,7 +784,7 @@ func (r *ClusterManagerReconciler) SetHyperregistryOidcConfig(ctx context.Contex
 	}
 	hostpath := ingress.Spec.Rules[0].Host
 	if err := util.SetHyperregistryOIDC(config, secret, hostpath); err != nil {
-		log.Error(err, "Failed to get ingress for hyperregistry")
+		log.Error(err, "Failed to set oidc configuration for hyperregistry")
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/cluster/clustermanager_controller_phases.go
+++ b/controllers/cluster/clustermanager_controller_phases.go
@@ -515,6 +515,7 @@ func (r *ClusterManagerReconciler) CreateArgocdClusterSecret(ctx context.Context
 	)
 	if err != nil {
 		log.Error(err, "Failed to marshal cluster authorization parameters")
+		return ctrl.Result{}, err
 	}
 
 	// master cluster에 secret 생성

--- a/controllers/k8s/secret_controller_phases.go
+++ b/controllers/k8s/secret_controller_phases.go
@@ -219,13 +219,17 @@ func (r *SecretReconciler) DeployArgocdResources(ctx context.Context, secret *co
 	// random suffix가 붙기때문에 조회하는 process가 번잡하므로 시크릿을 수동으로 생성
 	argocdManagerTokenSecret := &coreV1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				coreV1.ServiceAccountNameKey: util.ArgoServiceAccount,
+			},
 			Name: util.ArgoServiceAccountTokenSecret,
 		},
+		Type: coreV1.SecretTypeServiceAccountToken,
 	}
 	_, err = remoteClientset.
 		CoreV1().
 		Secrets(util.KubeNamespace).
-		Get(context.TODO(), util.ArgoServiceAccount, metav1.GetOptions{})
+		Get(context.TODO(), util.ArgoServiceAccountTokenSecret, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		_, err := remoteClientset.
 			CoreV1().

--- a/controllers/k8s/secret_controller_phases.go
+++ b/controllers/k8s/secret_controller_phases.go
@@ -215,8 +215,8 @@ func (r *SecretReconciler) DeployArgocdResources(ctx context.Context, secret *co
 		return ctrl.Result{}, err
 	}
 
-	// ArgoCD single cluster 연동을 위한 secret을 만들때 token을 조회 할 수 있도록
-	// argocd-manager-token 이름의 시크릿을 수동으로 생성
+	// service account 생성시 token secret이 자동으로 생성되지만
+	// random suffix가 붙기때문에 조회하는 process가 번잡하므로 시크릿을 수동으로 생성
 	argocdManagerTokenSecret := &coreV1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: util.ArgoServiceAccountTokenSecret,

--- a/controllers/util/const.go
+++ b/controllers/util/const.go
@@ -53,12 +53,13 @@ const (
 )
 
 const (
-	ArgoApiGroup           = "argocd.argoproj.io"
-	ArgoServiceAccount     = "argocd-manager"
-	ArgoClusterRole        = "argocd-manager-role"
-	ArgoClusterRoleBinding = "argocd-manager-role-binding"
-	ArgoSecretTypeCluster  = "cluster"
-	ArgoSecretTypeGit      = "repo"
+	ArgoApiGroup                  = "argocd.argoproj.io"
+	ArgoServiceAccount            = "argocd-manager"
+	ArgoServiceAccountTokenSecret = "argocd-manager-token"
+	ArgoClusterRole               = "argocd-manager-role"
+	ArgoClusterRoleBinding        = "argocd-manager-role-binding"
+	ArgoSecretTypeCluster         = "cluster"
+	ArgoSecretTypeGit             = "repo"
 )
 
 const (


### PR DESCRIPTION
ArgoCD 연동을 위한 secret을 생성할 때, admin정보가 아닌 service account정보를 사용하도록 변경