### PR TITLE
Timezone 설정 제거

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,8 +21,6 @@ spec:
         command:
         - /manager
         env:
-        - name: TZ
-          value: Asia/Seoul
         - name: HC_DOMAIN
           value: ${custom_domain}
         - name: AUTH_CLIENT_SECRET


### PR DESCRIPTION
argocd-installer에서 volumeMount를 통해 timezone을 설정할 수 있도록 env에서 TZ제거