### PR TITLE
[ims][285744] self-signed 인증서를 위한 로직 변경

### DIFF
--- a/controllers/hyperAuth/apiCaller.go
+++ b/controllers/hyperAuth/apiCaller.go
@@ -54,7 +54,7 @@ func GetTokenAsAdmin(secret *coreV1.Secret) (string, error) {
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	// Request with Client Object
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -87,7 +87,7 @@ func GetIdByClientId(clientId string, secret *coreV1.Secret) (string, error) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -142,7 +142,7 @@ func CreateClient(config ClientConfig, secret *coreV1.Secret) error {
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -191,7 +191,7 @@ func CreateClient(config ClientConfig, secret *coreV1.Secret) error {
 // 	req.Header.Add("Content-Type", "application/json")
 // 	req.Header.Add("Authorization", "Bearer "+token)
 
-// 	client := &http.Client{}
+// 	client := InsecureClient()
 // 	resp, err := client.Do(req)
 // 	if err != nil {
 // 		return err
@@ -237,7 +237,7 @@ func CreateClientLevelProtocolMapper(config ClientLevelProtocolMapperConfig, sec
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -286,7 +286,7 @@ func CreateClientLevelRole(config ClientLevelRoleConfig, secret *coreV1.Secret) 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -318,7 +318,7 @@ func GetUserIdByEmail(userEmail string, secret *coreV1.Secret) (string, error) {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -367,7 +367,7 @@ func GetClientRoleIdByRoleName(clientId string, roleName string, secret *coreV1.
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -438,7 +438,7 @@ func AddClientLevelRolesToUserRoleMapping(config ClientLevelRoleConfig, userEmai
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -469,7 +469,7 @@ func GetRealmRoleIdByRoleName(roleName string, secret *coreV1.Secret) (string, e
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -531,7 +531,7 @@ func AddRealmLevelRolesToUserRoleMapping(roleName string, userEmail string, secr
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -559,7 +559,7 @@ func GetClientScopesIdByName(name string, secret *coreV1.Secret) (string, error)
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -616,7 +616,7 @@ func AddClientScopeToClient(config ClientScopeMappingConfig, secret *coreV1.Secr
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -655,7 +655,7 @@ func DeleteClient(config ClientConfig, secret *coreV1.Secret) error {
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := InsecureClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/controllers/hyperAuth/util.go
+++ b/controllers/hyperAuth/util.go
@@ -14,7 +14,10 @@ limitations under the License.
 
 package hyperAuth
 
-import "net/http"
+import (
+	"crypto/tls"
+	"net/http"
+)
 
 func IsOK(check int) bool {
 	SuccessStatusList := map[int]bool{
@@ -31,4 +34,14 @@ func IsOK(check int) bool {
 
 func IsClientExist(id string) bool {
 	return id != ""
+}
+
+func InsecureClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
 }

--- a/controllers/util/hyperregistryApicaller.go
+++ b/controllers/util/hyperregistryApicaller.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -49,7 +50,13 @@ func SetHyperregistryOIDC(config OidcConfig, secret *coreV1.Secret, hostpath str
 	req.SetBasicAuth("admin", password)
 	req.Header.Add("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
[ims][285744] self-signed 인증서를 사용해도 정상 동작하도록 hyperauth, hyperregistry에 http콜을 insecure로 날리도록 변경